### PR TITLE
Fixing 'Attribute name 'async' associated with an element type 'scrip…

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ukuk_publications/xsl/core/page-structure.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ukuk_publications/xsl/core/page-structure.xsl
@@ -961,7 +961,7 @@
         <!-- Add a google analytics script if the key is present -->
         <xsl:if test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='google'][@qualifier='analytics']">
             <xsl:variable name="ga-property" select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='google'][@qualifier='analytics']"/>
-            <script async src="https://www.googletagmanager.com/gtag/js?id={$ga-property}"></script>
+            <script async="async" src="https://www.googletagmanager.com/gtag/js?id={$ga-property}"></script>
             <script>
                 <xsl:text>
                     window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
…t' must be followed by the ' = ' character' error