### PR TITLE
Fix issue of not displaying Context menu in sidebar when Item Versioning is turned on in XMLUI

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/core/navigation.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/core/navigation.xsl
@@ -122,14 +122,14 @@
                     </form>
                 </div>
             </xsl:if>
-            <!-- <xsl:apply-templates/> -->
             <!-- <JR> - 2022-08-23 - Added according to A. Schweer:
             https://dspace-tech.narkive.com/Sth573Ni/adding-menu-items-to-manikin-interface -->
             <xsl:apply-templates select="dri:list[@id='sidebar.menu.about-repo']" />
-            <xsl:apply-templates select="dri:list[@id='aspect.viewArtifacts.Navigation.list.browse']" />
+            <!--<xsl:apply-templates select="dri:list[@id='aspect.viewArtifacts.Navigation.list.browse']" />
             <xsl:apply-templates select="dri:list[@id='aspect.viewArtifacts.Navigation.list.context']" />
             <xsl:apply-templates select="dri:list[@id='aspect.viewArtifacts.Navigation.list.administrative']" />
-            <xsl:apply-templates select="dri:list[@id='aspect.discovery.Navigation.list.discovery']" />
+            <xsl:apply-templates select="dri:list[@id='aspect.discovery.Navigation.list.discovery']" />-->
+            <xsl:apply-templates/>
             <!-- DS-984 Add RSS Links to Options Box -->
             <xsl:if test="count(/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='feed']) != 0">
                 <div>


### PR DESCRIPTION
- caused by manually calling <xsl:apply-templates> for every aspect by its selector, e.g. `<xsl:apply-templates select="dri:list[@id='aspect.viewArtifacts.Navigation.list.context']" />` , 
  - `<xsl:apply-templates>` with selector should only be called for a new custom menu in sidebar ('About this Repository') and then followd by <xsl:apply-templates> without selector, like this:

```
<xsl:apply-templates select="dri:list[@id='sidebar.menu.about-repo']" />
<xsl:apply-templates/>
```