### PR TITLE
Feature/item page customizations

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ukuk_publications/xsl/core/navigation.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ukuk_publications/xsl/core/navigation.xsl
@@ -56,84 +56,91 @@
                     - COLLECTION pages
                     - ITEM pages
                 -->
-                <xsl:if test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='URI']/node() != ''">
-                    <div id="ds-search-option" class="ds-option-set">
-                        <!-- The form, complete with a text box and a button, all built from attributes referenced
-                    from under pageMeta. -->
-                        <form id="ds-search-form" class="" method="post">
-                            <xsl:attribute name="action">
-                                <xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='contextPath']"/>
-                                <xsl:value-of
-                                        select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='search'][@qualifier='simpleURL']"/>
-                            </xsl:attribute>
-                            <fieldset>
-                                <div class="input-group">
-                                    <input class="ds-text-field form-control" type="text" placeholder="xmlui.general.search"
-                                        i18n:attr="placeholder">
-                                        <xsl:attribute name="name">
-                                            <xsl:value-of
-                                                    select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='search'][@qualifier='queryField']"/>
-                                        </xsl:attribute>
-                                    </input>
-                                    <span class="input-group-btn">
-                                        <button class="ds-button-field btn btn-primary" title="xmlui.general.go" i18n:attr="title">
-                                            <span class="glyphicon glyphicon-search" aria-hidden="true"/>
-                                            <xsl:attribute name="onclick">
-                                                        <xsl:text>
-                                                            var radio = document.getElementById(&quot;ds-search-form-scope-container&quot;);
-                                                            if (radio != undefined &amp;&amp; radio.checked)
-                                                            {
-                                                            var form = document.getElementById(&quot;ds-search-form&quot;);
-                                                            form.action=
-                                                        </xsl:text>
-                                                <xsl:text>&quot;</xsl:text>
+                <xsl:choose>
+                    <xsl:when test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='URI']/node() = 'recent-submissions'">
+                        <!-- <JR> - 2024-02-20: Dont't render default search form on /recent-submissions page -->
+                    </xsl:when>
+                    <xsl:when test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='URI']/node() != ''">
+                        <!-- <JR> - 2024-02-20: Render default search form anywhere else EXCEPT the homepage (doesn't have a value of metadata[@element='request'][@qualifier='URI']) -->
+                        <div id="ds-search-option" class="ds-option-set">
+                            <!-- The form, complete with a text box and a button, all built from attributes referenced
+                        from under pageMeta. -->
+                            <form id="ds-search-form" class="" method="post">
+                                <xsl:attribute name="action">
+                                    <xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='contextPath']"/>
+                                    <xsl:value-of
+                                            select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='search'][@qualifier='simpleURL']"/>
+                                </xsl:attribute>
+                                <fieldset>
+                                    <div class="input-group">
+                                        <input class="ds-text-field form-control" type="text" placeholder="xmlui.general.search"
+                                            i18n:attr="placeholder">
+                                            <xsl:attribute name="name">
                                                 <xsl:value-of
-                                                        select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='contextPath']"/>
-                                                <xsl:text>/handle/&quot; + radio.value + &quot;</xsl:text>
-                                                <xsl:value-of
-                                                        select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='search'][@qualifier='simpleURL']"/>
-                                                <xsl:text>&quot; ; </xsl:text>
-                                                        <xsl:text>
-                                                            }
-                                                        </xsl:text>
+                                                        select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='search'][@qualifier='queryField']"/>
                                             </xsl:attribute>
-                                        </button>
-                                    </span>
-                                </div>
-
-                                <xsl:if test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='container']">
-                                    <div class="radio">
-                                        <label>
-                                            <input id="ds-search-form-scope-all" type="radio" name="scope" value=""
-                                                checked="checked"/>
-                                            <i18n:text>xmlui.dri2xhtml.structural.search</i18n:text>
-                                        </label>
-                                    </div>
-                                    <div class="radio">
-                                        <label>
-                                            <input id="ds-search-form-scope-container" type="radio" name="scope">
-                                                <xsl:attribute name="value">
+                                        </input>
+                                        <span class="input-group-btn">
+                                            <button class="ds-button-field btn btn-primary" title="xmlui.general.go" i18n:attr="title">
+                                                <span class="glyphicon glyphicon-search" aria-hidden="true"/>
+                                                <xsl:attribute name="onclick">
+                                                            <xsl:text>
+                                                                var radio = document.getElementById(&quot;ds-search-form-scope-container&quot;);
+                                                                if (radio != undefined &amp;&amp; radio.checked)
+                                                                {
+                                                                var form = document.getElementById(&quot;ds-search-form&quot;);
+                                                                form.action=
+                                                            </xsl:text>
+                                                    <xsl:text>&quot;</xsl:text>
                                                     <xsl:value-of
-                                                            select="substring-after(/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='container'],':')"/>
+                                                            select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='contextPath']"/>
+                                                    <xsl:text>/handle/&quot; + radio.value + &quot;</xsl:text>
+                                                    <xsl:value-of
+                                                            select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='search'][@qualifier='simpleURL']"/>
+                                                    <xsl:text>&quot; ; </xsl:text>
+                                                            <xsl:text>
+                                                                }
+                                                            </xsl:text>
                                                 </xsl:attribute>
-                                            </input>
-                                            <xsl:choose>
-                                                <xsl:when
-                                                        test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='containerType']/text() = 'type:community'">
-                                                    <i18n:text>xmlui.dri2xhtml.structural.search-in-community</i18n:text>
-                                                </xsl:when>
-                                                <xsl:otherwise>
-                                                    <i18n:text>xmlui.dri2xhtml.structural.search-in-collection</i18n:text>
-                                                </xsl:otherwise>
-
-                                            </xsl:choose>
-                                        </label>
+                                            </button>
+                                        </span>
                                     </div>
-                                </xsl:if>
-                            </fieldset>
-                        </form>
-                    </div>
-                </xsl:if>
+
+                                    <xsl:if test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='container']">
+                                        <div class="radio">
+                                            <label>
+                                                <input id="ds-search-form-scope-all" type="radio" name="scope" value=""
+                                                    checked="checked"/>
+                                                <i18n:text>xmlui.dri2xhtml.structural.search</i18n:text>
+                                            </label>
+                                        </div>
+                                        <div class="radio">
+                                            <label>
+                                                <input id="ds-search-form-scope-container" type="radio" name="scope">
+                                                    <xsl:attribute name="value">
+                                                        <xsl:value-of
+                                                                select="substring-after(/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='container'],':')"/>
+                                                    </xsl:attribute>
+                                                </input>
+                                                <xsl:choose>
+                                                    <xsl:when
+                                                            test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='containerType']/text() = 'type:community'">
+                                                        <i18n:text>xmlui.dri2xhtml.structural.search-in-community</i18n:text>
+                                                    </xsl:when>
+                                                    <xsl:otherwise>
+                                                        <i18n:text>xmlui.dri2xhtml.structural.search-in-collection</i18n:text>
+                                                    </xsl:otherwise>
+
+                                                </xsl:choose>
+                                            </label>
+                                        </div>
+                                    </xsl:if>
+                                </fieldset>
+                            </form>
+                        </div>
+                    </xsl:when>
+                    <xsl:otherwise></xsl:otherwise>
+                </xsl:choose>
             </xsl:if>
             <!-- <xsl:apply-templates/> -->
             <!-- <JR> - 2022-08-23 - Added according to A. Schweer:

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ukuk_publications/xsl/custom/homepage-news.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ukuk_publications/xsl/custom/homepage-news.xsl
@@ -239,6 +239,18 @@
 
 <xsl:template match="/dri:document/dri:body/dri:div[@id='aspect.artifactbrowser.CommunityBrowser.div.comunity-browser'][@n='comunity-browser']">
 
+    <!--  If we are no homepage, don't render community-browser...-->
+    <xsl:choose>
+        <xsl:when test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='URI'] = ''">
+
+        </xsl:when>
+        <xsl:otherwise>
+            <!--  ...apply necessary templates otherwise, i.e. render communities and collections on /community-list page -->
+            <xsl:apply-templates/>
+        </xsl:otherwise>
+    </xsl:choose>
+
+
 </xsl:template>
 
 <xsl:template match="/dri:document/dri:body/dri:div[@id='aspect.discovery.SiteRecentSubmissions.div.site-home'][@n='site-home']">

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ukuk_publications/xsl/custom/recent-submissions.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ukuk_publications/xsl/custom/recent-submissions.xsl
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xsl:stylesheet
+    xmlns:i18n="http://apache.org/cocoon/i18n/2.1"
+    xmlns:dri="http://di.tamu.edu/DRI/1.0/"
+    xmlns:mets="http://www.loc.gov/METS/"
+    xmlns:dim="http://www.dspace.org/xmlns/dspace/dim"
+    xmlns:xlink="http://www.w3.org/TR/xlink/"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:atom="http://www.w3.org/2005/Atom"
+    xmlns:ore="http://www.openarchives.org/ore/terms/"
+    xmlns:oreatom="http://www.openarchives.org/ore/atom/"
+    xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:xalan="http://xml.apache.org/xalan"
+    xmlns:encoder="xalan://java.net.URLEncoder"
+    xmlns:util="org.dspace.app.xmlui.utils.XSLUtils"
+    xmlns:jstring="java.lang.String"
+    xmlns:rights="http://cosimo.stanford.edu/sdr/metsrights/"
+    xmlns:confman="org.dspace.core.ConfigurationManager"
+    exclude-result-prefixes="xalan encoder i18n dri mets dim xlink xsl util jstring rights confman">
+    <xsl:import href="../aspect/artifactbrowser/item-view-license.xsl" />
+    <xsl:import href="utility.xsl"/>
+
+    <xsl:output indent="yes"/>
+
+
+    <xsl:template match="/dri:document/dri:body/dri:div[@n='main-recent-submissions']/dri:div[@n='main-recent-submissions-search']">
+    <!-- Basic example can be found at https://getbootstrap.com/docs/3.4/examples/jumbotron/ -->
+        <div class="row recent-submissions-search-form-row">
+            <div id="recent-submissions-search-form" class="col-lg-12 recent-submissions-search-form-column">
+                <xsl:call-template name="addSearch"/>   
+            </div>
+        </div>
+        
+    </xsl:template>
+
+    <xsl:template name="addSearch">
+        <xsl:if test="not(contains(/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='URI'], 'discover'))">
+            <div id="ds-search-option" class="ds-option-set">
+                <!-- The form, complete with a text box and a button, all built from attributes referenced
+                from under pageMeta. -->
+                <form id="ds-search-form" class="" method="post">
+                    <xsl:attribute name="action">
+                        <xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='contextPath']"/>
+                        <xsl:value-of
+                                select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='search'][@qualifier='simpleURL']"/>
+                    </xsl:attribute>
+                    <fieldset>
+                        <div class="input-group">
+                            <input class="ds-text-field form-control" type="text" placeholder="xmlui.general.search"
+                                    i18n:attr="placeholder">
+                                <xsl:attribute name="name">
+                                    <xsl:value-of
+                                            select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='search'][@qualifier='queryField']"/>
+                                </xsl:attribute>
+                            </input>
+                            <span class="input-group-btn">
+                                <button class="ds-button-field btn btn-primary" title="xmlui.general.go" i18n:attr="title" id="homepage-jumbotron-search-button">
+                                    <span class="glyphicon glyphicon-search" aria-hidden="true"/>
+                                    <xsl:attribute name="onclick">
+                                                <xsl:text>
+                                                    var radio = document.getElementById(&quot;ds-search-form-scope-container&quot;);
+                                                    if (radio != undefined &amp;&amp; radio.checked)
+                                                    {
+                                                    var form = document.getElementById(&quot;ds-search-form&quot;);
+                                                    form.action=
+                                                </xsl:text>
+                                        <xsl:text>&quot;</xsl:text>
+                                        <xsl:value-of
+                                                select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='contextPath']"/>
+                                        <xsl:text>/handle/&quot; + radio.value + &quot;</xsl:text>
+                                        <xsl:value-of
+                                                select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='search'][@qualifier='simpleURL']"/>
+                                        <xsl:text>&quot; ; </xsl:text>
+                                                <xsl:text>
+                                                    }
+                                                </xsl:text>
+                                    </xsl:attribute>
+                                </button>
+                            </span>
+                        </div>
+
+                        <xsl:if test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='container']">
+                            <div class="radio">
+                                <label>
+                                    <input id="ds-search-form-scope-all" type="radio" name="scope" value=""
+                                            checked="checked"/>
+                                    <i18n:text>xmlui.dri2xhtml.structural.search</i18n:text>
+                                </label>
+                            </div>
+                            <div class="radio">
+                                <label>
+                                    <input id="ds-search-form-scope-container" type="radio" name="scope">
+                                        <xsl:attribute name="value">
+                                            <xsl:value-of
+                                                    select="substring-after(/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='container'],':')"/>
+                                        </xsl:attribute>
+                                    </input>
+                                    <xsl:choose>
+                                        <xsl:when
+                                                test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='focus'][@qualifier='containerType']/text() = 'type:community'">
+                                            <i18n:text>xmlui.dri2xhtml.structural.search-in-community</i18n:text>
+                                        </xsl:when>
+                                        <xsl:otherwise>
+                                            <i18n:text>xmlui.dri2xhtml.structural.search-in-collection</i18n:text>
+                                        </xsl:otherwise>
+
+                                    </xsl:choose>
+                                </label>
+                            </div>
+                        </xsl:if>
+                    </fieldset>
+                </form>
+            </div>
+        </xsl:if>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ukuk_publications/xsl/theme.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ukuk_publications/xsl/theme.xsl
@@ -53,11 +53,15 @@
     <!-- <JR> - 2022-09-05 - Trying to import custom homepage-news.xsl, so all related templates could be stored there, 
         therefore avoiding cluttering main theme.xsl file -->
     <xsl:import href="custom/homepage-news.xsl"/>
+    <!-- <JR> - 2024-02-20: New custom XSL file for /recent-submissions page, where we want to add  search form -->
+    <xsl:import href="custom/recent-submissions.xsl"/>
     <xsl:output indent="yes"/>
 
     <!-- <JR> - 2022-09-05 - THIS WORKS FOR PLAYING WITH NEWS ON HOMEPAGE, WHEN CALLED FROM HERE -->
     <!-- <xsl:template match="/dri:document/dri:body/dri:div[@id='file.news.div.news'][@n='news']">
         <h2>Ahoj z theme.xsl</h2>
     </xsl:template> -->
+
+    
 
 </xsl:stylesheet>


### PR DESCRIPTION
Fixed:

- major issue where communities and collections were not rendering on /community-list page because of the template that suppresed rendering community-browser on homepage (definied in homepage-news.xsl)

Added:
- search form on /recent-submissions page