### PR TITLE
Added translation key for updated (published) publication version

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -2223,6 +2223,7 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.item-publication-version-submittedVersion">submitted version</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-publication-version-acceptedVersion">accepted version</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-publication-version-publishedVersion">published version</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-publication-version-updatedVersion">updated version</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-publication-version-none">no other version</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-publication-version-unknown">unknown version</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-publication-accessRights.openAccess">open access</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_cs.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_cs.xml
@@ -2239,6 +2239,7 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.item-publication-version-submittedVersion">preprint</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-publication-version-acceptedVersion">postprint</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-publication-version-publishedVersion">vydavatelská verze</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-publication-version-updatedVersion">aktualizovaná vydavatelská verze</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-publication-version-none">žádná další verze</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-publication-version-unknown">neznámá verze</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-publication-accessRights.openAccess">open access</message>


### PR DESCRIPTION
 - missing key: xmlui.dri2xhtml.METS-1.0.item-publication-version-updatedVersion